### PR TITLE
Prepend to fish_complete_path to load completions before generated_completions

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -49,7 +49,7 @@ function fish_completion_sync --on-variable XDG_DATA_DIRS
       if set -q FISH_COMPLETION_DEBUG
         echo "adding: $data_dir"
       end
-      set -a fish_complete_path $data_dir
+      set -p fish_complete_path $data_dir
       set -a FISH_COMPLETION_ADDITIONS $data_dir
     end
   end


### PR DESCRIPTION
This no longer works in fish 4.0 due to `~/.cache/fish/generated_completion` being loaded before the newly appended completions.

For more context, see https://github.com/fish-shell/fish-shell/issues/11246.